### PR TITLE
added url option for Tree plots

### DIFF
--- a/R/d3plus.R
+++ b/R/d3plus.R
@@ -38,7 +38,7 @@ d3plus <- function(d, type, width = NULL, height = NULL,...) {
   attributes <- args$attributes %||% NULL
 
   if(type == "tree"){
-    vars <- c("id","size","color") # add vars to opts
+    vars <- c("id","size","color","url") # add vars to opts
     data_names <- as.list(names(data))
     names(data_names) <- vars[1:length(data_names)]
     settings <- list(

--- a/inst/htmlwidgets/d3plus.js
+++ b/inst/htmlwidgets/d3plus.js
@@ -45,6 +45,24 @@ HTMLWidgets.widget({
             var id = x.settings.data_names.id;
             var size = x.settings.data_names.size;
             var color = x.settings.data_names.color;
+
+            // include legend when color supplied
+            var color_opt = (sample_data[0].hasOwnProperty('color')) ? true : false;
+
+            var mouse_opt;
+            if (sample_data[0].hasOwnProperty('url')) {
+              mouse_opt = {"move": false,
+                               "over": false,
+                               "click": function(value, viz){
+                                           window.open(value.url, '_blank');
+                                         }
+                          };
+              color_opt = false; // switch off legend when using URL
+
+            } else {
+              mouse_opt = true;
+            }
+
             d3plus
                 .container("#" + vizId) // container DIV to hold the visualization
                 .data(sample_data) // data to use with the visualization
@@ -52,6 +70,8 @@ HTMLWidgets.widget({
                 .id(id) // nesting keys
                 .size(size) // key name to size bubbles
                 .color(color)
+                .mouse(mouse_opt)
+                .legend(color_opt) // in future, better to enable legend attribute
                 .draw()
         }
 
@@ -140,7 +160,7 @@ HTMLWidgets.widget({
             } else {
                 var text = "label"
             }
-            var lang = x.settings.lang || "en_US"; // "zh_CN","en_US","es_ES","pt_BR" 
+            var lang = x.settings.lang || "en_US"; // "zh_CN","en_US","es_ES","pt_BR"
             var focus = x.settings.focus || false;
             var showTooltip = x.settings.showTooltip;
             if(!showTooltip){
@@ -164,7 +184,7 @@ HTMLWidgets.widget({
                 .size(vars.size)
                 .id(["id"])
                 // https://groups.google.com/forum/#!topic/d3plus/q4iXv0rpzQo
-                // .text("label")  
+                // .text("label")
                 // .id(["group","id"])
                 .text(text)
                 .tooltip(["id", "label"])
@@ -201,7 +221,7 @@ HTMLWidgets.widget({
             }
             console.log(x.data)
             var focusDropdown = x.settings.focusDropdown;
-            var lang = x.settings.lang || "en_US"; // "zh_CN","en_US","es_ES","pt_BR" 
+            var lang = x.settings.lang || "en_US"; // "zh_CN","en_US","es_ES","pt_BR"
             var showLegend = x.settings.showLegend || false
             var ui = [];
             if (focusDropdown) {

--- a/inst/htmlwidgets/d3plus.js
+++ b/inst/htmlwidgets/d3plus.js
@@ -45,6 +45,19 @@ HTMLWidgets.widget({
             var id = x.settings.data_names.id;
             var size = x.settings.data_names.size;
             var color = x.settings.data_names.color;
+
+            if (sample_data[0].hasOwnProperty('url')) {
+              var mouse_opt = {"move": false,
+                               "over": false,
+                               "click": function(value, viz){
+                                           window.open(value.url, '_blank');
+                                         }
+                          };
+
+            } else {
+              var mouse_opt = false;
+            }
+
             d3plus
                 .container("#" + vizId) // container DIV to hold the visualization
                 .data(sample_data) // data to use with the visualization
@@ -52,6 +65,13 @@ HTMLWidgets.widget({
                 .id(id) // nesting keys
                 .size(size) // key name to size bubbles
                 .color(color)
+                .mouse(mouse_opt)
+                .font([ "Helvetica Neue" ,
+                        "HelveticaNeue" ,
+                        "Helvetica" ,
+                        "Arial" ,
+                        "sans-serif" ])
+                .legend(false)
                 .draw()
         }
 
@@ -140,7 +160,7 @@ HTMLWidgets.widget({
             } else {
                 var text = "label"
             }
-            var lang = x.settings.lang || "en_US"; // "zh_CN","en_US","es_ES","pt_BR" 
+            var lang = x.settings.lang || "en_US"; // "zh_CN","en_US","es_ES","pt_BR"
             var focus = x.settings.focus || false;
             var showTooltip = x.settings.showTooltip;
             if(!showTooltip){
@@ -164,7 +184,7 @@ HTMLWidgets.widget({
                 .size(vars.size)
                 .id(["id"])
                 // https://groups.google.com/forum/#!topic/d3plus/q4iXv0rpzQo
-                // .text("label")  
+                // .text("label")
                 // .id(["group","id"])
                 .text(text)
                 .tooltip(["id", "label"])
@@ -201,7 +221,7 @@ HTMLWidgets.widget({
             }
             console.log(x.data)
             var focusDropdown = x.settings.focusDropdown;
-            var lang = x.settings.lang || "en_US"; // "zh_CN","en_US","es_ES","pt_BR" 
+            var lang = x.settings.lang || "en_US"; // "zh_CN","en_US","es_ES","pt_BR"
             var showLegend = x.settings.showLegend || false
             var ui = [];
             if (focusDropdown) {


### PR DESCRIPTION
Hi,
I have added a small bit of code so that elements in a tree map can be used as links to other sites. I have tried to keep the addition as small as possible to maintain current functionality. 

A URL can now be specified  in column four of the data input.  Using the column position means that to use URL's the color column also needs to be specified.

When the URL column is present all other mouse events and the legend are disabled. A future update could allow for these settings to be modified. 